### PR TITLE
fix: Update default applications in base.nix

### DIFF
--- a/modules/macos/base.nix
+++ b/modules/macos/base.nix
@@ -82,7 +82,7 @@
       entries = [
         {path = "/Applications/DEVONthink 3.app";}
         {path = "/Applications/Drafts.app";}
-        {path = "/Applications/Safari.app";}
+        {path = "/Applications/Arc.app";}
         {path = "/System/Applications/Messages.app";}
       ];
     };


### PR DESCRIPTION
Changed default browser application from Safari to Arc in the base.nix configuration file.